### PR TITLE
Cleaning up apt cache to optimize disk space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		zlib1g-dev \
-	&& apt-get clean && rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y \
 		bzr \
@@ -30,4 +30,4 @@ RUN apt-get update && apt-get install -y \
 		git \
 		mercurial \
 		subversion \
-	&& apt-get clean && rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I tested it and got this :
before : 793.5 MB
after : 784.1 MB
All this 9.4MB is unnecessary files, as recommended in Debian mkimage :
"delete all the apt list files since they're big and get stale quickly
this forces "apt-get update" in dependent images, which is also good"
https://github.com/docker/docker/blob/master/contrib/mkimage/debootstrap
