### PR TITLE
Add libyaml-dev (especially for Ruby 1.9, but generally useful)

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
 		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
 		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes docker-library/ruby#10
