### PR TITLE
Install `curl` and `wget` to simplify downstream Dockerfiles

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -31,3 +31,7 @@ RUN apt-get update && apt-get install -y \
 		mercurial \
 		subversion \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y \
+		curl \
+	&& rm -rf /var/lib/apt/lists/*

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -31,3 +31,7 @@ RUN apt-get update && apt-get install -y \
 		mercurial \
 		subversion \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y \
+		curl \
+	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #7 with an `apt-get install -y curl wget` for both `jessie` and `wheezy`.
