### PR TITLE
Slim down the micro versions

### DIFF
--- a/jessie/micro/Dockerfile
+++ b/jessie/micro/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		cvs \
 		git \
@@ -8,7 +8,9 @@ RUN apt-get update && apt-get install -y \
 		subversion \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		ca-certificates \
 		curl \
+		openssh-client \
 		wget \
 	&& rm -rf /var/lib/apt/lists/*

--- a/sid/micro/Dockerfile
+++ b/sid/micro/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:sid
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		cvs \
 		git \
@@ -8,7 +8,9 @@ RUN apt-get update && apt-get install -y \
 		subversion \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		ca-certificates \
 		curl \
+		openssh-client \
 		wget \
 	&& rm -rf /var/lib/apt/lists/*

--- a/wheezy/micro/Dockerfile
+++ b/wheezy/micro/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:wheezy
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		cvs \
 		git \
@@ -8,7 +8,9 @@ RUN apt-get update && apt-get install -y \
 		subversion \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		ca-certificates \
 		curl \
+		openssh-client \
 		wget \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We need to test the ramifications since regular buildpacks are based on these.

Old size: 
```console
$ docker images buildpack-deps
REPOSITORY       TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
buildpack-deps   sid-micro           5d88036e88d8        About an hour ago   392.2 MB
buildpack-deps   wheezy-micro        9cb126bc1b2b        2 weeks ago         244.4 MB
buildpack-deps   jessie-micro        c8e506fcb72c        2 weeks ago         390.9 MB
```

New size:
```console
REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
buildpack-deps      sid-micro           d151033f5745        About a minute ago   294 MB
buildpack-deps      wheezy-micro        4f56dff6b939        About a minute ago   213.2 MB
buildpack-deps      jessie-micro        c23d2cc8de68        8 minutes ago        293.5 MB
```