### PR TITLE
add gcc variant

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -17,7 +17,7 @@ echo '# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)'
 for version in "${versions[@]}"; do
 	versionAliases=( $version ${aliases[$version]} )
 	
-	for variant in curl scm; do
+	for variant in curl scm gcc; do
 		commit="$(git log -1 --format='format:%H' -- "$version/$variant")"
 		echo
 		for va in "${versionAliases[@]}"; do

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -1,8 +1,6 @@
-FROM buildpack-deps:jessie-scm
+FROM buildpack-deps:jessie-gcc
 
 RUN apt-get update && apt-get install -y \
-		autoconf \
-		build-essential \
 		imagemagick \
 		libbz2-dev \
 		libcurl4-openssl-dev \

--- a/jessie/gcc/Dockerfile
+++ b/jessie/gcc/Dockerfile
@@ -1,0 +1,6 @@
+FROM buildpack-deps:jessie-scm
+
+RUN apt-get update && apt-get install -y \
+		gcc libc6-dev make pkg-config autoconf \
+		--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*

--- a/jessie/gcc/Dockerfile
+++ b/jessie/gcc/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:jessie-scm
 
 RUN apt-get update && apt-get install -y \
-		gcc libc6-dev make pkg-config autoconf \
+		gcc g++ libc6-dev make pkg-config autoconf \
 		--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*

--- a/sid/Dockerfile
+++ b/sid/Dockerfile
@@ -1,8 +1,6 @@
-FROM buildpack-deps:sid-scm
+FROM buildpack-deps:sid-gcc
 
 RUN apt-get update && apt-get install -y \
-		autoconf \
-		build-essential \
 		imagemagick \
 		libbz2-dev \
 		libcurl4-openssl-dev \

--- a/sid/gcc/Dockerfile
+++ b/sid/gcc/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:sid-scm
 
-RUN apt-get update && apt-get install -y \
-		gcc libc6-dev make pkg-config autoconf \
+RUN apt-getn update && apt-get install -y \
+		gcc g++ libc6-dev make pkg-config autoconf \
 		--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*

--- a/sid/gcc/Dockerfile
+++ b/sid/gcc/Dockerfile
@@ -1,0 +1,6 @@
+FROM buildpack-deps:sid-scm
+
+RUN apt-get update && apt-get install -y \
+		gcc libc6-dev make pkg-config autoconf \
+		--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -1,8 +1,6 @@
-FROM buildpack-deps:wheezy-scm
+FROM buildpack-deps:wheezy-gcc
 
 RUN apt-get update && apt-get install -y \
-		autoconf \
-		build-essential \
 		imagemagick \
 		libbz2-dev \
 		libcurl4-openssl-dev \

--- a/wheezy/gcc/Dockerfile
+++ b/wheezy/gcc/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:wheezy-scm
 
 RUN apt-get update && apt-get install -y \
-		gcc libc6-dev make pkg-config autoconf \
+		gcc g++ libc6-dev make pkg-config autoconf \
 		--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*

--- a/wheezy/gcc/Dockerfile
+++ b/wheezy/gcc/Dockerfile
@@ -1,0 +1,6 @@
+FROM buildpack-deps:wheezy-scm
+
+RUN apt-get update && apt-get install -y \
+		gcc libc6-dev make pkg-config autoconf \
+		--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
based on the discussion on https://github.com/joyent/docker-node/pull/2#issuecomment-71506264 adding a `-gcc` variant that could share between language stacks with a C API.

The goal of the variant is to include just enough bytes to cover building native package:
- Python C extensions
- Node native modules
- cgo packages

