### PR TITLE
Add liblzma-dev

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
 		libffi-dev \
 		libglib2.0-dev \
 		libjpeg-dev \
+		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libmysqlclient-dev \

--- a/sid/Dockerfile
+++ b/sid/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
 		libffi-dev \
 		libglib2.0-dev \
 		libjpeg-dev \
+		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libmysqlclient-dev \

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
 		libffi-dev \
 		libglib2.0-dev \
 		libjpeg-dev \
+		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libmysqlclient-dev \


### PR DESCRIPTION
libzlma is (among other things of course) used in Python to build the lzma module. 

Considering it's a small package (and that e.g. zlib is in here), I thought it might make sense to include it here.

Cheers, 