### PR TITLE
Add squeeze

### DIFF
--- a/squeeze/Dockerfile
+++ b/squeeze/Dockerfile
@@ -1,0 +1,26 @@
+FROM buildpack-deps:squeeze-scm
+
+RUN apt-get update && apt-get install -y \
+		autoconf \
+		build-essential \
+		imagemagick \
+		libbz2-dev \
+		libcurl4-openssl-dev \
+		libevent-dev \
+		libffi-dev \
+		libglib2.0-dev \
+		libjpeg-dev \
+		liblzma-dev \
+		libmagickcore-dev \
+		libmagickwand-dev \
+		libmysqlclient-dev \
+		libncurses-dev \
+		libpq-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt-dev \
+		libyaml-dev \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*

--- a/squeeze/curl/Dockerfile
+++ b/squeeze/curl/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:squeeze
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		ca-certificates \
+		curl \
+		wget \
+	&& rm -rf /var/lib/apt/lists/*

--- a/squeeze/scm/Dockerfile
+++ b/squeeze/scm/Dockerfile
@@ -1,0 +1,9 @@
+FROM buildpack-deps:squeeze-curl
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		bzr \
+		git \
+		mercurial \
+		openssh-client \
+		subversion \
+	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I have created buildpack-deps for squeeze.
Squeeze has official image, so I expected it to be supported, it wasn't, hence this pull.

I need squeeze to test that nothing will break/change so I can help few projects/apps to catch up with future/docker.