### PR TITLE
Replace `build-essential` meta-package with the actual packages

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,8 +1,10 @@
 FROM buildpack-deps:SUITE-scm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \
+		automake \
 		bzip2 \
+		file \
 		g++ \
 		gcc \
 		imagemagick \
@@ -22,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
+		libtool \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,9 +2,12 @@ FROM buildpack-deps:SUITE-scm
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
-		build-essential \
+		bzip2 \
+		g++ \
+		gcc \
 		imagemagick \
 		libbz2-dev \
+		libc6-dev \
 		libcurl4-openssl-dev \
 		libevent-dev \
 		libffi-dev \
@@ -22,5 +25,8 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -2,9 +2,12 @@ FROM buildpack-deps:jessie-scm
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
-		build-essential \
+		bzip2 \
+		g++ \
+		gcc \
 		imagemagick \
 		libbz2-dev \
+		libc6-dev \
 		libcurl4-openssl-dev \
 		libevent-dev \
 		libffi-dev \
@@ -22,5 +25,8 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -1,8 +1,10 @@
 FROM buildpack-deps:jessie-scm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \
+		automake \
 		bzip2 \
+		file \
 		g++ \
 		gcc \
 		imagemagick \
@@ -22,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
+		libtool \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/precise/Dockerfile
+++ b/precise/Dockerfile
@@ -2,9 +2,12 @@ FROM buildpack-deps:precise-scm
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
-		build-essential \
+		bzip2 \
+		g++ \
+		gcc \
 		imagemagick \
 		libbz2-dev \
+		libc6-dev \
 		libcurl4-openssl-dev \
 		libevent-dev \
 		libffi-dev \
@@ -22,5 +25,8 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*

--- a/precise/Dockerfile
+++ b/precise/Dockerfile
@@ -1,8 +1,10 @@
 FROM buildpack-deps:precise-scm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \
+		automake \
 		bzip2 \
+		file \
 		g++ \
 		gcc \
 		imagemagick \
@@ -22,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
+		libtool \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/sid/Dockerfile
+++ b/sid/Dockerfile
@@ -2,9 +2,12 @@ FROM buildpack-deps:sid-scm
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
-		build-essential \
+		bzip2 \
+		g++ \
+		gcc \
 		imagemagick \
 		libbz2-dev \
+		libc6-dev \
 		libcurl4-openssl-dev \
 		libevent-dev \
 		libffi-dev \
@@ -22,5 +25,8 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*

--- a/sid/Dockerfile
+++ b/sid/Dockerfile
@@ -1,8 +1,10 @@
 FROM buildpack-deps:sid-scm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \
+		automake \
 		bzip2 \
+		file \
 		g++ \
 		gcc \
 		imagemagick \
@@ -22,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
+		libtool \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/squeeze/Dockerfile
+++ b/squeeze/Dockerfile
@@ -2,9 +2,12 @@ FROM buildpack-deps:squeeze-scm
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
-		build-essential \
+		bzip2 \
+		g++ \
+		gcc \
 		imagemagick \
 		libbz2-dev \
+		libc6-dev \
 		libcurl4-openssl-dev \
 		libevent-dev \
 		libffi-dev \
@@ -22,5 +25,8 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*

--- a/squeeze/Dockerfile
+++ b/squeeze/Dockerfile
@@ -1,8 +1,10 @@
 FROM buildpack-deps:squeeze-scm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \
+		automake \
 		bzip2 \
+		file \
 		g++ \
 		gcc \
 		imagemagick \
@@ -22,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
+		libtool \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -1,8 +1,10 @@
 FROM buildpack-deps:stretch-scm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \
+		automake \
 		bzip2 \
+		file \
 		g++ \
 		gcc \
 		imagemagick \
@@ -22,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
+		libtool \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -2,9 +2,12 @@ FROM buildpack-deps:stretch-scm
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
-		build-essential \
+		bzip2 \
+		g++ \
+		gcc \
 		imagemagick \
 		libbz2-dev \
+		libc6-dev \
 		libcurl4-openssl-dev \
 		libevent-dev \
 		libffi-dev \
@@ -22,5 +25,8 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -2,9 +2,12 @@ FROM buildpack-deps:trusty-scm
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
-		build-essential \
+		bzip2 \
+		g++ \
+		gcc \
 		imagemagick \
 		libbz2-dev \
+		libc6-dev \
 		libcurl4-openssl-dev \
 		libevent-dev \
 		libffi-dev \
@@ -22,5 +25,8 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -1,8 +1,10 @@
 FROM buildpack-deps:trusty-scm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \
+		automake \
 		bzip2 \
+		file \
 		g++ \
 		gcc \
 		imagemagick \
@@ -22,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
+		libtool \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/utopic/Dockerfile
+++ b/utopic/Dockerfile
@@ -1,8 +1,10 @@
 FROM buildpack-deps:utopic-scm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \
+		automake \
 		bzip2 \
+		file \
 		g++ \
 		gcc \
 		imagemagick \
@@ -22,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
+		libtool \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/utopic/Dockerfile
+++ b/utopic/Dockerfile
@@ -2,9 +2,12 @@ FROM buildpack-deps:utopic-scm
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
-		build-essential \
+		bzip2 \
+		g++ \
+		gcc \
 		imagemagick \
 		libbz2-dev \
+		libc6-dev \
 		libcurl4-openssl-dev \
 		libevent-dev \
 		libffi-dev \
@@ -22,5 +25,8 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*

--- a/vivid/Dockerfile
+++ b/vivid/Dockerfile
@@ -2,9 +2,12 @@ FROM buildpack-deps:vivid-scm
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
-		build-essential \
+		bzip2 \
+		g++ \
+		gcc \
 		imagemagick \
 		libbz2-dev \
+		libc6-dev \
 		libcurl4-openssl-dev \
 		libevent-dev \
 		libffi-dev \
@@ -22,5 +25,8 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*

--- a/vivid/Dockerfile
+++ b/vivid/Dockerfile
@@ -1,8 +1,10 @@
 FROM buildpack-deps:vivid-scm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \
+		automake \
 		bzip2 \
+		file \
 		g++ \
 		gcc \
 		imagemagick \
@@ -22,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
+		libtool \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -1,8 +1,10 @@
 FROM buildpack-deps:wheezy-scm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \
+		automake \
 		bzip2 \
+		file \
 		g++ \
 		gcc \
 		imagemagick \
@@ -22,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
+		libtool \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -2,9 +2,12 @@ FROM buildpack-deps:wheezy-scm
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
-		build-essential \
+		bzip2 \
+		g++ \
+		gcc \
 		imagemagick \
 		libbz2-dev \
+		libc6-dev \
 		libcurl4-openssl-dev \
 		libevent-dev \
 		libffi-dev \
@@ -22,5 +25,8 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*

--- a/wily/Dockerfile
+++ b/wily/Dockerfile
@@ -1,8 +1,10 @@
 FROM buildpack-deps:wily-scm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \
+		automake \
 		bzip2 \
+		file \
 		g++ \
 		gcc \
 		imagemagick \
@@ -22,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
+		libtool \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/wily/Dockerfile
+++ b/wily/Dockerfile
@@ -2,9 +2,12 @@ FROM buildpack-deps:wily-scm
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
-		build-essential \
+		bzip2 \
+		g++ \
+		gcc \
 		imagemagick \
 		libbz2-dev \
+		libc6-dev \
 		libcurl4-openssl-dev \
 		libevent-dev \
 		libffi-dev \
@@ -22,5 +25,8 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #16.
Closes #20.

```diff
# diff inst-pkgs inst-pkgs-new (ie: packages no longer installed since none are added)
17d16
< ii  build-essentia 11.7         amd64        Informational list of build-essen
36d34
< ii  dpkg-dev       1.17.25      all          Debian package development tools
39d36
< ii  fakeroot       1.20.2-1     amd64        tool for simulating superuser pri
77,79d73
< ii  libalgorithm-d 1.19.02-3    all          module to find differences betwee
< ii  libalgorithm-d 0.04-3+b1    amd64        module to find differences betwee
< ii  libalgorithm-m 0.08-2       all          Perl module for three-way merge o
127d120
< ii  libdpkg-perl   1.17.25      all          Dpkg perl modules
141d133
< ii  libfakeroot:am 1.20.2-1     amd64        tool for simulating superuser pri
145d136
< ii  libfile-fcntll 0.22-1+b1    amd64        Perl module for file locking with
305d295
< ii  libtimedate-pe 2.3000-2     all          collection of modules to manipula
```