### PR TITLE
Add libwebp-dev

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/precise/Dockerfile
+++ b/precise/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/sid/Dockerfile
+++ b/sid/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/squeeze/Dockerfile
+++ b/squeeze/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/utopic/Dockerfile
+++ b/utopic/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/vivid/Dockerfile
+++ b/vivid/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \

--- a/wily/Dockerfile
+++ b/wily/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
 		libxslt-dev \
 		libyaml-dev \


### PR DESCRIPTION
Not entirely sure if this process is correct, but I added the dependency into `Dockerfile.template`, then ran `./update.sh` and it seemed to do the right thing.

webp is needed for a number of image processing libraries, and we already have `libjpeg-dev` along with imagemagick packages.