### PR TITLE
Add procps to :scm variants since it's fairly common in build systems

### DIFF
--- a/Dockerfile.template-scm
+++ b/Dockerfile.template-scm
@@ -1,9 +1,12 @@
 FROM buildpack-deps:SUITE-curl
 
+# procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
+		\
+		procps \
 	&& rm -rf /var/lib/apt/lists/*

--- a/jessie/scm/Dockerfile
+++ b/jessie/scm/Dockerfile
@@ -1,9 +1,12 @@
 FROM buildpack-deps:jessie-curl
 
+# procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
+		\
+		procps \
 	&& rm -rf /var/lib/apt/lists/*

--- a/precise/scm/Dockerfile
+++ b/precise/scm/Dockerfile
@@ -1,9 +1,12 @@
 FROM buildpack-deps:precise-curl
 
+# procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
+		\
+		procps \
 	&& rm -rf /var/lib/apt/lists/*

--- a/sid/scm/Dockerfile
+++ b/sid/scm/Dockerfile
@@ -1,9 +1,12 @@
 FROM buildpack-deps:sid-curl
 
+# procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
+		\
+		procps \
 	&& rm -rf /var/lib/apt/lists/*

--- a/stretch/scm/Dockerfile
+++ b/stretch/scm/Dockerfile
@@ -1,9 +1,12 @@
 FROM buildpack-deps:stretch-curl
 
+# procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
+		\
+		procps \
 	&& rm -rf /var/lib/apt/lists/*

--- a/trusty/scm/Dockerfile
+++ b/trusty/scm/Dockerfile
@@ -1,9 +1,12 @@
 FROM buildpack-deps:trusty-curl
 
+# procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
+		\
+		procps \
 	&& rm -rf /var/lib/apt/lists/*

--- a/vivid/scm/Dockerfile
+++ b/vivid/scm/Dockerfile
@@ -1,9 +1,12 @@
 FROM buildpack-deps:vivid-curl
 
+# procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
+		\
+		procps \
 	&& rm -rf /var/lib/apt/lists/*

--- a/wheezy/scm/Dockerfile
+++ b/wheezy/scm/Dockerfile
@@ -1,9 +1,12 @@
 FROM buildpack-deps:wheezy-curl
 
+# procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
+		\
+		procps \
 	&& rm -rf /var/lib/apt/lists/*

--- a/wily/scm/Dockerfile
+++ b/wily/scm/Dockerfile
@@ -1,9 +1,12 @@
 FROM buildpack-deps:wily-curl
 
+# procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzr \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
+		\
+		procps \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This needs to be explicit since stretch has managed to remove "procps" from minbase again! :tada: