### PR TITLE
fix: `apt-get install` RUN commands should always call `apt-get clean`

### DIFF
--- a/Dockerfile-curl.template
+++ b/Dockerfile-curl.template
@@ -4,4 +4,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
 		wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile-scm.template
+++ b/Dockerfile-scm.template
@@ -9,4 +9,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		subversion \
 		\
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -35,4 +35,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/jessie/curl/Dockerfile
+++ b/jessie/curl/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
 		wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/jessie/scm/Dockerfile
+++ b/jessie/scm/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		subversion \
 		\
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/precise/Dockerfile
+++ b/precise/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/precise/curl/Dockerfile
+++ b/precise/curl/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
 		wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/precise/scm/Dockerfile
+++ b/precise/scm/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		subversion \
 		\
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/sid/Dockerfile
+++ b/sid/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/sid/curl/Dockerfile
+++ b/sid/curl/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
 		wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/sid/scm/Dockerfile
+++ b/sid/scm/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		subversion \
 		\
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/stretch/curl/Dockerfile
+++ b/stretch/curl/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
 		wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/stretch/scm/Dockerfile
+++ b/stretch/scm/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		subversion \
 		\
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/trusty/curl/Dockerfile
+++ b/trusty/curl/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
 		wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/trusty/scm/Dockerfile
+++ b/trusty/scm/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		subversion \
 		\
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/wheezy/curl/Dockerfile
+++ b/wheezy/curl/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
 		wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/wheezy/scm/Dockerfile
+++ b/wheezy/scm/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		subversion \
 		\
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/wily/Dockerfile
+++ b/wily/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/wily/curl/Dockerfile
+++ b/wily/curl/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
 		wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/wily/scm/Dockerfile
+++ b/wily/scm/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		subversion \
 		\
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/xenial/curl/Dockerfile
+++ b/xenial/curl/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
 		wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/xenial/scm/Dockerfile
+++ b/xenial/scm/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		subversion \
 		\
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Running `apt-get clean` at the end of an `apt-get install` RUN command
will help keep the apt cache from getting into a weird state. Cache
being in a weird state can cause subsequent `apt-get install` RUN
commands to fail.

fixes docker-library/buildpack-deps#40
