### PR TITLE
Add libgdbm-dev for python and ruby (libgdbm3 is already pulled in by perl)

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libdb-dev \
 		libevent-dev \
 		libffi-dev \
+		libgdbm-dev \
 		libgeoip-dev \
 		libglib2.0-dev \
 		libjpeg-dev \

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libdb-dev \
 		libevent-dev \
 		libffi-dev \
+		libgdbm-dev \
 		libgeoip-dev \
 		libglib2.0-dev \
 		libjpeg-dev \

--- a/precise/Dockerfile
+++ b/precise/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libdb-dev \
 		libevent-dev \
 		libffi-dev \
+		libgdbm-dev \
 		libgeoip-dev \
 		libglib2.0-dev \
 		libjpeg-dev \

--- a/sid/Dockerfile
+++ b/sid/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libdb-dev \
 		libevent-dev \
 		libffi-dev \
+		libgdbm-dev \
 		libgeoip-dev \
 		libglib2.0-dev \
 		libjpeg-dev \

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libdb-dev \
 		libevent-dev \
 		libffi-dev \
+		libgdbm-dev \
 		libgeoip-dev \
 		libglib2.0-dev \
 		libjpeg-dev \

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libdb-dev \
 		libevent-dev \
 		libffi-dev \
+		libgdbm-dev \
 		libgeoip-dev \
 		libglib2.0-dev \
 		libjpeg-dev \

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libdb-dev \
 		libevent-dev \
 		libffi-dev \
+		libgdbm-dev \
 		libgeoip-dev \
 		libglib2.0-dev \
 		libjpeg-dev \

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libdb-dev \
 		libevent-dev \
 		libffi-dev \
+		libgdbm-dev \
 		libgeoip-dev \
 		libglib2.0-dev \
 		libjpeg-dev \


### PR DESCRIPTION
This will fix most of https://github.com/docker-library/python/issues/151, specifically for the regular python variants.

```
After this operation, 167 kB of additional disk space will be used.
```

#### related tasks:
- [ ] add `libgdbm-dev` to the alpine and slim python images
- [ ] drop `libgdbm-dev` out of the regular ruby images