### PR TITLE
Add apt-transport-https package

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,7 @@
 FROM buildpack-deps:SUITE-scm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
 		autoconf \
 		automake \
 		bzip2 \

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -1,6 +1,7 @@
 FROM buildpack-deps:jessie-scm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
 		autoconf \
 		automake \
 		bzip2 \

--- a/precise/Dockerfile
+++ b/precise/Dockerfile
@@ -1,6 +1,7 @@
 FROM buildpack-deps:precise-scm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
 		autoconf \
 		automake \
 		bzip2 \

--- a/sid/Dockerfile
+++ b/sid/Dockerfile
@@ -1,6 +1,7 @@
 FROM buildpack-deps:sid-scm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
 		autoconf \
 		automake \
 		bzip2 \

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -1,6 +1,7 @@
 FROM buildpack-deps:stretch-scm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
 		autoconf \
 		automake \
 		bzip2 \

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -1,6 +1,7 @@
 FROM buildpack-deps:trusty-scm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
 		autoconf \
 		automake \
 		bzip2 \

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -1,6 +1,7 @@
 FROM buildpack-deps:wheezy-scm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
 		autoconf \
 		automake \
 		bzip2 \

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -1,6 +1,7 @@
 FROM buildpack-deps:xenial-scm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
 		autoconf \
 		automake \
 		bzip2 \

--- a/yakkety/Dockerfile
+++ b/yakkety/Dockerfile
@@ -1,6 +1,7 @@
 FROM buildpack-deps:yakkety-scm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
 		autoconf \
 		automake \
 		bzip2 \

--- a/zesty/Dockerfile
+++ b/zesty/Dockerfile
@@ -1,6 +1,7 @@
 FROM buildpack-deps:zesty-scm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
 		autoconf \
 		automake \
 		bzip2 \


### PR DESCRIPTION
... to allow ```https``` urls in sources lists.

Fixes #55 .