### PR TITLE
Add "dpkg-dev" to the full variants

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,6 +6,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \

--- a/artful/Dockerfile
+++ b/artful/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \

--- a/sid/Dockerfile
+++ b/sid/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \

--- a/zesty/Dockerfile
+++ b/zesty/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \


### PR DESCRIPTION
This provides us with `dpkg-architecture`, which is a really useful tool for implementing multi-architecture support (especially when a "GNU triple" is needed).

See https://github.com/docker-library/php/pull/429 for an example of it being used (and links to other PRs using it as well).