### PR TITLE
Remove "bzr" from buster and sid scm variants

### DIFF
--- a/buster/scm/Dockerfile
+++ b/buster/scm/Dockerfile
@@ -2,7 +2,6 @@ FROM buildpack-deps:buster-curl
 
 # procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		bzr \
 		git \
 		mercurial \
 		openssh-client \

--- a/sid/scm/Dockerfile
+++ b/sid/scm/Dockerfile
@@ -2,7 +2,6 @@ FROM buildpack-deps:sid-curl
 
 # procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		bzr \
 		git \
 		mercurial \
 		openssh-client \

--- a/update.sh
+++ b/update.sh
@@ -26,10 +26,25 @@ for version in "${versions[@]}"; do
 		src="Dockerfile${variant:+-$variant}.template"
 		trg="$version${variant:+/$variant}/Dockerfile"
 		mkdir -p "$(dirname "$trg")"
-		( set -x && sed '
-			s!DIST!'"$dist"'!g;
-			s!SUITE!'"$version"'!g;
-		' "$src" > "$trg" )
+		(
+			set -x
+			sed \
+				-e 's!DIST!'"$dist"'!g' \
+				-e 's!SUITE!'"$version"'!g' \
+				"$src" > "$trg"
+		)
+		if [ "$dist" = 'debian' ]; then
+			# remove "bzr" from buster and later
+			case "$version" in
+				wheezy|jessie|stretch) ;;
+				*)
+					(
+						set -x
+						sed -i '/bzr/d' "$version/scm/Dockerfile"
+					)
+					;;
+			esac
+		fi
 	done
 	travisEnv+='\n  - VERSION='"$version"
 done


### PR DESCRIPTION
This is party to resolve the following build failure in current sid, but also partly because bzr usage is esoteric:

```
The following packages have unmet dependencies:
 bzr : Depends: python-bzrlib (<= 2.7.0+bzr6622-7.1~) but it is not going to be installed
       Depends: python-bzrlib (>= 2.7.0+bzr6622-7) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```