### PR TITLE
Install libncursesw5-dev for ncurses wide character support

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -26,6 +26,7 @@ RUN set -ex; \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libncurses-dev \
+		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \
 		libreadline-dev \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -25,7 +25,7 @@ RUN set -ex; \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libncurses-dev \
+		libncurses5-dev \
 		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \

--- a/artful/Dockerfile
+++ b/artful/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libncurses-dev \
+		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \
 		libreadline-dev \

--- a/artful/Dockerfile
+++ b/artful/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libncurses-dev \
+		libncurses5-dev \
 		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libncurses-dev \
+		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \
 		libreadline-dev \

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libncurses-dev \
+		libncurses5-dev \
 		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libncurses-dev \
+		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \
 		libreadline-dev \

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libncurses-dev \
+		libncurses5-dev \
 		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \

--- a/sid/Dockerfile
+++ b/sid/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libncurses-dev \
+		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \
 		libreadline-dev \

--- a/sid/Dockerfile
+++ b/sid/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libncurses-dev \
+		libncurses5-dev \
 		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libncurses-dev \
+		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \
 		libreadline-dev \

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libncurses-dev \
+		libncurses5-dev \
 		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libncurses-dev \
+		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \
 		libreadline-dev \

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libncurses-dev \
+		libncurses5-dev \
 		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libncurses-dev \
+		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \
 		libreadline-dev \

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libncurses-dev \
+		libncurses5-dev \
 		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libncurses-dev \
+		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \
 		libreadline-dev \

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libncurses-dev \
+		libncurses5-dev \
 		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \

--- a/zesty/Dockerfile
+++ b/zesty/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
 		libmagickcore-dev \
 		libmagickwand-dev \
 		libncurses-dev \
+		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \
 		libreadline-dev \

--- a/zesty/Dockerfile
+++ b/zesty/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libncurses-dev \
+		libncurses5-dev \
 		libncursesw5-dev \
 		libpng-dev \
 		libpq-dev \


### PR DESCRIPTION
See docker-library/python#235

A number of packages should be built against `libncursesw5` instead of `libncurses5`, most notably, Python. The two libraries do no conflict.