### PR TITLE
Add package apt-transport-https

### DIFF
--- a/Dockerfile-curl.template
+++ b/Dockerfile-curl.template
@@ -3,6 +3,9 @@ FROM {{ env.dist }}:{{ env.codename }}
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+{{ if [ "stretch", "xenial" ] | index(env.codename) then ( -}}
+		apt-transport-https \
+{{ ) else "" end -}}
 		ca-certificates \
 		curl \
 		netbase \

--- a/debian/stretch/curl/Dockerfile
+++ b/debian/stretch/curl/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:stretch
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		apt-transport-https \
 		ca-certificates \
 		curl \
 		netbase \

--- a/ubuntu/xenial/curl/Dockerfile
+++ b/ubuntu/xenial/curl/Dockerfile
@@ -9,6 +9,7 @@ FROM ubuntu:xenial
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		apt-transport-https \
 		ca-certificates \
 		curl \
 		netbase \


### PR DESCRIPTION
Hi

I can't use apt on stretch image when packages are exposed on https.

It seems package ```apt-transport-https``` present on image ```debian:buster``` do not exists on ```debian:stretch```, so I force installation to allow APT repositories over https.

Thx for your work 