### PR TITLE
Add "shared-mime-info"

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -42,6 +42,7 @@ RUN set -ex; \
 		libyaml-dev \
 		make \
 		patch \
+		shared-mime-info \
 		unzip \
 		xz-utils \
 		zlib1g-dev \

--- a/debian/bullseye/Dockerfile
+++ b/debian/bullseye/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex; \
 		libyaml-dev \
 		make \
 		patch \
+		shared-mime-info \
 		unzip \
 		xz-utils \
 		zlib1g-dev \

--- a/debian/buster/Dockerfile
+++ b/debian/buster/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex; \
 		libyaml-dev \
 		make \
 		patch \
+		shared-mime-info \
 		unzip \
 		xz-utils \
 		zlib1g-dev \

--- a/debian/sid/Dockerfile
+++ b/debian/sid/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex; \
 		libyaml-dev \
 		make \
 		patch \
+		shared-mime-info \
 		unzip \
 		xz-utils \
 		zlib1g-dev \

--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex; \
 		libyaml-dev \
 		make \
 		patch \
+		shared-mime-info \
 		unzip \
 		xz-utils \
 		zlib1g-dev \

--- a/ubuntu/bionic/Dockerfile
+++ b/ubuntu/bionic/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex; \
 		libyaml-dev \
 		make \
 		patch \
+		shared-mime-info \
 		unzip \
 		xz-utils \
 		zlib1g-dev \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex; \
 		libyaml-dev \
 		make \
 		patch \
+		shared-mime-info \
 		unzip \
 		xz-utils \
 		zlib1g-dev \

--- a/ubuntu/groovy/Dockerfile
+++ b/ubuntu/groovy/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex; \
 		libyaml-dev \
 		make \
 		patch \
+		shared-mime-info \
 		unzip \
 		xz-utils \
 		zlib1g-dev \

--- a/ubuntu/hirsute/Dockerfile
+++ b/ubuntu/hirsute/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex; \
 		libyaml-dev \
 		make \
 		patch \
+		shared-mime-info \
 		unzip \
 		xz-utils \
 		zlib1g-dev \

--- a/ubuntu/xenial/Dockerfile
+++ b/ubuntu/xenial/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex; \
 		libyaml-dev \
 		make \
 		patch \
+		shared-mime-info \
 		unzip \
 		xz-utils \
 		zlib1g-dev \


### PR DESCRIPTION
This is especially for `freedesktop.org.xml`, which is needed for a recent change to the `mimemagic` Ruby Gem (due to licensing incompatibility).

See https://github.com/docker-library/ruby/issues/344 for more details (https://github.com/mimemagicrb/mimemagic/issues/97 -> https://github.com/mimemagicrb/mimemagic/commit/cd65290a28e58974ff0c5fa1d3f2ce858035f177).