### PR TITLE
Remove explicit `dirmngr` reference

### DIFF
--- a/Dockerfile-curl.template
+++ b/Dockerfile-curl.template
@@ -5,6 +5,7 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
+		gnupg \
 		netbase \
 		wget \
 {{ if env.dist == "ubuntu" then ( -}}
@@ -13,13 +14,3 @@ RUN set -eux; \
 {{ ) else "" end -}}
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi

--- a/debian/bookworm/curl/Dockerfile
+++ b/debian/bookworm/curl/Dockerfile
@@ -11,17 +11,8 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
+		gnupg \
 		netbase \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi

--- a/debian/bullseye/curl/Dockerfile
+++ b/debian/bullseye/curl/Dockerfile
@@ -11,17 +11,8 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
+		gnupg \
 		netbase \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi

--- a/debian/buster/curl/Dockerfile
+++ b/debian/buster/curl/Dockerfile
@@ -11,17 +11,8 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
+		gnupg \
 		netbase \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi

--- a/debian/sid/curl/Dockerfile
+++ b/debian/sid/curl/Dockerfile
@@ -11,17 +11,8 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
+		gnupg \
 		netbase \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi

--- a/ubuntu/bionic/curl/Dockerfile
+++ b/ubuntu/bionic/curl/Dockerfile
@@ -11,19 +11,10 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
+		gnupg \
 		netbase \
 		wget \
 # https://bugs.debian.org/929417
 		tzdata \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi

--- a/ubuntu/focal/curl/Dockerfile
+++ b/ubuntu/focal/curl/Dockerfile
@@ -11,19 +11,10 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
+		gnupg \
 		netbase \
 		wget \
 # https://bugs.debian.org/929417
 		tzdata \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi

--- a/ubuntu/jammy/curl/Dockerfile
+++ b/ubuntu/jammy/curl/Dockerfile
@@ -11,19 +11,10 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
+		gnupg \
 		netbase \
 		wget \
 # https://bugs.debian.org/929417
 		tzdata \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi

--- a/ubuntu/kinetic/curl/Dockerfile
+++ b/ubuntu/kinetic/curl/Dockerfile
@@ -11,19 +11,10 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
+		gnupg \
 		netbase \
 		wget \
 # https://bugs.debian.org/929417
 		tzdata \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi

--- a/ubuntu/lunar/curl/Dockerfile
+++ b/ubuntu/lunar/curl/Dockerfile
@@ -11,19 +11,10 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
+		gnupg \
 		netbase \
 		wget \
 # https://bugs.debian.org/929417
 		tzdata \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi


### PR DESCRIPTION
This is pulled in automatically via `gnupg`, and moved from `Recommends` to `Depends` in https://salsa.debian.org/debian/gnupg2/-/commit/99474ad900a8bcdd0e7b68f986fec0013fc01470, which has been part of `src:gnupg2` since 2.1.21-4 (and every supported version of both Debian _and_ Ubuntu here have 2.2.x 😇).