### PR TITLE
Add "sq" as a "gpg" alternative

### DIFF
--- a/Dockerfile-curl.template
+++ b/Dockerfile-curl.template
@@ -7,6 +7,19 @@ RUN set -eux; \
 		curl \
 		gnupg \
 		netbase \
+{{ if [
+	# we want versions of "sq" that contain https://gitlab.com/sequoia-pgp/sequoia/-/commit/b41e1504cd29097328cb21f95808c9972188499e (and thus "sq keyserver" subcommands)
+	# https://packages.debian.org/sq
+	# https://packages.ubuntu.com/sq
+	"bullseye", # 0.24
+	"buster",   # no sq
+	"jammy",    # 0.25
+	"focal",    # no sq
+	"bionic",   # no sq
+	empty # trailing comma
+] | index(env.codename) then "" else ( -}}
+		sq \
+{{ ) end -}}
 		wget \
 {{ if env.dist == "ubuntu" then ( -}}
 # https://bugs.debian.org/929417

--- a/debian/bookworm/curl/Dockerfile
+++ b/debian/bookworm/curl/Dockerfile
@@ -13,6 +13,7 @@ RUN set -eux; \
 		curl \
 		gnupg \
 		netbase \
+		sq \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/debian/sid/curl/Dockerfile
+++ b/debian/sid/curl/Dockerfile
@@ -13,6 +13,7 @@ RUN set -eux; \
 		curl \
 		gnupg \
 		netbase \
+		sq \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/ubuntu/kinetic/curl/Dockerfile
+++ b/ubuntu/kinetic/curl/Dockerfile
@@ -13,6 +13,7 @@ RUN set -eux; \
 		curl \
 		gnupg \
 		netbase \
+		sq \
 		wget \
 # https://bugs.debian.org/929417
 		tzdata \

--- a/ubuntu/lunar/curl/Dockerfile
+++ b/ubuntu/lunar/curl/Dockerfile
@@ -13,6 +13,7 @@ RUN set -eux; \
 		curl \
 		gnupg \
 		netbase \
+		sq \
 		wget \
 # https://bugs.debian.org/929417
 		tzdata \


### PR DESCRIPTION
(where new enough to include `sq keyserver` subcommands)

See https://sequoia-pgp.org/ and https://gitlab.com/sequoia-pgp/sequoia-sq

Basic example `sq` workflow:

```console
$ sq keyserver --server hkps://keys.openpgp.org get --output key 'B42F6819007F00F88E364FD4036A9C25BF357DD4'
$ wget https://github.com/tianon/gosu/releases/download/1.16/gosu-amd64{,.asc}
$ sq verify --signer-cert key --detached gosu-amd64.asc gosu-amd64
Good signature from 036A9C25BF357DD4
1 good signature.
```