### PR TITLE
Cleanup comments and remove unnecessary conditional

### DIFF
--- a/Dockerfile-scm.template
+++ b/Dockerfile-scm.template
@@ -1,7 +1,8 @@
 FROM buildpack-deps:{{ env.codename }}-curl
 
-# procps is very common in build systems, and is a reasonably small package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 {{
 if [
 	"focal", "groovy"
@@ -14,5 +15,7 @@ if [
 		openssh-client \
 		subversion \
 		\
+# procps is very common in build systems, and is a reasonably small package
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,6 +6,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		default-libmysqlclient-dev \
 		dpkg-dev \
 		file \
 		g++ \
@@ -43,15 +44,5 @@ RUN set -ex; \
 		unzip \
 		xz-utils \
 		zlib1g-dev \
-		\
-# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
-		$( \
-# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
-			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
-				echo 'default-libmysqlclient-dev'; \
-			else \
-				echo 'libmysqlclient-dev'; \
-			fi \
-		) \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/debian/bookworm/Dockerfile
+++ b/debian/bookworm/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		default-libmysqlclient-dev \
 		dpkg-dev \
 		file \
 		g++ \
@@ -49,15 +50,5 @@ RUN set -ex; \
 		unzip \
 		xz-utils \
 		zlib1g-dev \
-		\
-# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
-		$( \
-# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
-			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
-				echo 'default-libmysqlclient-dev'; \
-			else \
-				echo 'libmysqlclient-dev'; \
-			fi \
-		) \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/debian/bookworm/scm/Dockerfile
+++ b/debian/bookworm/scm/Dockerfile
@@ -6,12 +6,15 @@
 
 FROM buildpack-deps:bookworm-curl
 
-# procps is very common in build systems, and is a reasonably small package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
 		\
+# procps is very common in build systems, and is a reasonably small package
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/debian/bullseye/Dockerfile
+++ b/debian/bullseye/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		default-libmysqlclient-dev \
 		dpkg-dev \
 		file \
 		g++ \
@@ -49,15 +50,5 @@ RUN set -ex; \
 		unzip \
 		xz-utils \
 		zlib1g-dev \
-		\
-# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
-		$( \
-# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
-			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
-				echo 'default-libmysqlclient-dev'; \
-			else \
-				echo 'libmysqlclient-dev'; \
-			fi \
-		) \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/debian/bullseye/scm/Dockerfile
+++ b/debian/bullseye/scm/Dockerfile
@@ -6,12 +6,15 @@
 
 FROM buildpack-deps:bullseye-curl
 
-# procps is very common in build systems, and is a reasonably small package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
 		\
+# procps is very common in build systems, and is a reasonably small package
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/debian/buster/Dockerfile
+++ b/debian/buster/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		default-libmysqlclient-dev \
 		dpkg-dev \
 		file \
 		g++ \
@@ -49,15 +50,5 @@ RUN set -ex; \
 		unzip \
 		xz-utils \
 		zlib1g-dev \
-		\
-# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
-		$( \
-# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
-			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
-				echo 'default-libmysqlclient-dev'; \
-			else \
-				echo 'libmysqlclient-dev'; \
-			fi \
-		) \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/debian/buster/scm/Dockerfile
+++ b/debian/buster/scm/Dockerfile
@@ -6,12 +6,15 @@
 
 FROM buildpack-deps:buster-curl
 
-# procps is very common in build systems, and is a reasonably small package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
 		\
+# procps is very common in build systems, and is a reasonably small package
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/debian/sid/Dockerfile
+++ b/debian/sid/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		default-libmysqlclient-dev \
 		dpkg-dev \
 		file \
 		g++ \
@@ -49,15 +50,5 @@ RUN set -ex; \
 		unzip \
 		xz-utils \
 		zlib1g-dev \
-		\
-# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
-		$( \
-# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
-			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
-				echo 'default-libmysqlclient-dev'; \
-			else \
-				echo 'libmysqlclient-dev'; \
-			fi \
-		) \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/debian/sid/scm/Dockerfile
+++ b/debian/sid/scm/Dockerfile
@@ -6,12 +6,15 @@
 
 FROM buildpack-deps:sid-curl
 
-# procps is very common in build systems, and is a reasonably small package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
 		\
+# procps is very common in build systems, and is a reasonably small package
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/debian/trixie/Dockerfile
+++ b/debian/trixie/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		default-libmysqlclient-dev \
 		dpkg-dev \
 		file \
 		g++ \
@@ -49,15 +50,5 @@ RUN set -ex; \
 		unzip \
 		xz-utils \
 		zlib1g-dev \
-		\
-# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
-		$( \
-# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
-			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
-				echo 'default-libmysqlclient-dev'; \
-			else \
-				echo 'libmysqlclient-dev'; \
-			fi \
-		) \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/debian/trixie/scm/Dockerfile
+++ b/debian/trixie/scm/Dockerfile
@@ -6,12 +6,15 @@
 
 FROM buildpack-deps:trixie-curl
 
-# procps is very common in build systems, and is a reasonably small package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
 		\
+# procps is very common in build systems, and is a reasonably small package
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		default-libmysqlclient-dev \
 		dpkg-dev \
 		file \
 		g++ \
@@ -49,15 +50,5 @@ RUN set -ex; \
 		unzip \
 		xz-utils \
 		zlib1g-dev \
-		\
-# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
-		$( \
-# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
-			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
-				echo 'default-libmysqlclient-dev'; \
-			else \
-				echo 'libmysqlclient-dev'; \
-			fi \
-		) \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/ubuntu/focal/scm/Dockerfile
+++ b/ubuntu/focal/scm/Dockerfile
@@ -6,13 +6,16 @@
 
 FROM buildpack-deps:focal-curl
 
-# procps is very common in build systems, and is a reasonably small package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		bzr \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
 		\
+# procps is very common in build systems, and is a reasonably small package
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/ubuntu/jammy/Dockerfile
+++ b/ubuntu/jammy/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		default-libmysqlclient-dev \
 		dpkg-dev \
 		file \
 		g++ \
@@ -49,15 +50,5 @@ RUN set -ex; \
 		unzip \
 		xz-utils \
 		zlib1g-dev \
-		\
-# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
-		$( \
-# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
-			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
-				echo 'default-libmysqlclient-dev'; \
-			else \
-				echo 'libmysqlclient-dev'; \
-			fi \
-		) \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/ubuntu/jammy/scm/Dockerfile
+++ b/ubuntu/jammy/scm/Dockerfile
@@ -6,12 +6,15 @@
 
 FROM buildpack-deps:jammy-curl
 
-# procps is very common in build systems, and is a reasonably small package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
 		\
+# procps is very common in build systems, and is a reasonably small package
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/ubuntu/lunar/Dockerfile
+++ b/ubuntu/lunar/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		default-libmysqlclient-dev \
 		dpkg-dev \
 		file \
 		g++ \
@@ -49,15 +50,5 @@ RUN set -ex; \
 		unzip \
 		xz-utils \
 		zlib1g-dev \
-		\
-# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
-		$( \
-# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
-			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
-				echo 'default-libmysqlclient-dev'; \
-			else \
-				echo 'libmysqlclient-dev'; \
-			fi \
-		) \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/ubuntu/lunar/scm/Dockerfile
+++ b/ubuntu/lunar/scm/Dockerfile
@@ -6,12 +6,15 @@
 
 FROM buildpack-deps:lunar-curl
 
-# procps is very common in build systems, and is a reasonably small package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
 		\
+# procps is very common in build systems, and is a reasonably small package
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/ubuntu/mantic/Dockerfile
+++ b/ubuntu/mantic/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		default-libmysqlclient-dev \
 		dpkg-dev \
 		file \
 		g++ \
@@ -49,15 +50,5 @@ RUN set -ex; \
 		unzip \
 		xz-utils \
 		zlib1g-dev \
-		\
-# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
-		$( \
-# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
-			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
-				echo 'default-libmysqlclient-dev'; \
-			else \
-				echo 'libmysqlclient-dev'; \
-			fi \
-		) \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/ubuntu/mantic/scm/Dockerfile
+++ b/ubuntu/mantic/scm/Dockerfile
@@ -6,12 +6,15 @@
 
 FROM buildpack-deps:mantic-curl
 
-# procps is very common in build systems, and is a reasonably small package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
 		\
+# procps is very common in build systems, and is a reasonably small package
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/ubuntu/noble/Dockerfile
+++ b/ubuntu/noble/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
 		autoconf \
 		automake \
 		bzip2 \
+		default-libmysqlclient-dev \
 		dpkg-dev \
 		file \
 		g++ \
@@ -49,15 +50,5 @@ RUN set -ex; \
 		unzip \
 		xz-utils \
 		zlib1g-dev \
-		\
-# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
-		$( \
-# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
-			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
-				echo 'default-libmysqlclient-dev'; \
-			else \
-				echo 'libmysqlclient-dev'; \
-			fi \
-		) \
 	; \
 	rm -rf /var/lib/apt/lists/*

--- a/ubuntu/noble/scm/Dockerfile
+++ b/ubuntu/noble/scm/Dockerfile
@@ -6,12 +6,15 @@
 
 FROM buildpack-deps:noble-curl
 
-# procps is very common in build systems, and is a reasonably small package
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		mercurial \
 		openssh-client \
 		subversion \
 		\
+# procps is very common in build systems, and is a reasonably small package
 		procps \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Also, switch to using `set -eux` + `;` chains consistently (no more `&&`).

(I have a planned follow-up to this for which https://tracker.debian.org/news/1492892/accepted-apt-278-source-into-unstable/ is a spoiler, but I need a new `debian` rebuilt with APT 2.7.8 in it before I can send that one. :sweat_smile:)