### PR TITLE
Switch to new `apt-get dist-clean` command

### DIFF
--- a/Dockerfile-curl.template
+++ b/Dockerfile-curl.template
@@ -1,3 +1,4 @@
+{{ include "shared" -}}
 FROM {{ env.dist }}:{{ env.codename }}
 
 RUN set -eux; \
@@ -26,4 +27,4 @@ RUN set -eux; \
 		tzdata \
 {{ ) else "" end -}}
 	; \
-	rm -rf /var/lib/apt/lists/*
+	{{ apt_get_dist_clean }}

--- a/Dockerfile-scm.template
+++ b/Dockerfile-scm.template
@@ -1,3 +1,4 @@
+{{ include "shared" -}}
 FROM buildpack-deps:{{ env.codename }}-curl
 
 RUN set -eux; \
@@ -18,4 +19,4 @@ if [
 # procps is very common in build systems, and is a reasonably small package
 		procps \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	{{ apt_get_dist_clean }}

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,3 +1,4 @@
+{{ include "shared" -}}
 FROM buildpack-deps:{{ env.codename }}-scm
 
 RUN set -ex; \
@@ -45,4 +46,4 @@ RUN set -ex; \
 		xz-utils \
 		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	{{ apt_get_dist_clean }}

--- a/debian/sid/Dockerfile
+++ b/debian/sid/Dockerfile
@@ -51,4 +51,4 @@ RUN set -ex; \
 		xz-utils \
 		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean

--- a/debian/sid/curl/Dockerfile
+++ b/debian/sid/curl/Dockerfile
@@ -16,4 +16,4 @@ RUN set -eux; \
 		sq \
 		wget \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean

--- a/debian/sid/scm/Dockerfile
+++ b/debian/sid/scm/Dockerfile
@@ -17,4 +17,4 @@ RUN set -eux; \
 # procps is very common in build systems, and is a reasonably small package
 		procps \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean

--- a/shared.jq
+++ b/shared.jq
@@ -1,0 +1,27 @@
+def apt_get_dist_clean:
+	if [
+		# only suites with APT 2.7.8+ have "apt-get dist-clean"
+		# https://tracker.debian.org/news/1492892/accepted-apt-278-source-into-unstable/
+
+		# https://tracker.debian.org/pkg/apt
+		# https://packages.debian.org/apt
+		"trixie", # TODO once 2.7.8 migrates to testing (and images are rebuilt), this should be removed!
+		"bookworm",
+		"bullseye",
+		"buster",
+
+		# https://launchpad.net/ubuntu/+source/apt
+		# https://packages.ubuntu.com/apt
+		"noble", # TODO once 2.7.8+ makes it into devel (and images are rebuilt), this should be removed!
+		"mantic",
+		"lunar",
+		"jammy",
+		"focal",
+
+		empty
+	] | index(env.codename) then
+		"rm -rf /var/lib/apt/lists/*"
+	else
+		"apt-get dist-clean"
+	end
+;


### PR DESCRIPTION
APT [2.7.8](https://tracker.debian.org/news/1492892/accepted-apt-278-source-into-unstable/) has a new `apt-get dist-clean` command designed exactly for our use case of "remove APT lists" and it's much better than our hammer. 🎉