### PR TITLE
Add `apt-get dist-clean` to Debian Testing / Trixie 🎉

### DIFF
--- a/debian/trixie/Dockerfile
+++ b/debian/trixie/Dockerfile
@@ -51,4 +51,4 @@ RUN set -ex; \
 		xz-utils \
 		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean

--- a/debian/trixie/curl/Dockerfile
+++ b/debian/trixie/curl/Dockerfile
@@ -16,4 +16,4 @@ RUN set -eux; \
 		sq \
 		wget \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean

--- a/debian/trixie/scm/Dockerfile
+++ b/debian/trixie/scm/Dockerfile
@@ -17,4 +17,4 @@ RUN set -eux; \
 # procps is very common in build systems, and is a reasonably small package
 		procps \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean

--- a/shared.jq
+++ b/shared.jq
@@ -5,7 +5,6 @@ def apt_get_dist_clean:
 
 		# https://tracker.debian.org/pkg/apt
 		# https://packages.debian.org/apt
-		"trixie", # TODO once 2.7.8 migrates to testing (and images are rebuilt), this should be removed!
 		"bookworm",
 		"bullseye",
 		"buster",


### PR DESCRIPTION
As of https://github.com/docker-library/official-images/pull/16155, we're OK to go!! :smile: