### PR TITLE
Update `apt-get dist-clean` logic to include noble

### DIFF
--- a/shared.jq
+++ b/shared.jq
@@ -11,7 +11,6 @@ def apt_get_dist_clean:
 
 		# https://launchpad.net/ubuntu/+source/apt
 		# https://packages.ubuntu.com/apt
-		"noble", # TODO once 2.7.8+ makes it into devel (and images are rebuilt), this should be removed!
 		"mantic",
 		"jammy",
 		"focal",

--- a/ubuntu/noble/Dockerfile
+++ b/ubuntu/noble/Dockerfile
@@ -51,4 +51,4 @@ RUN set -ex; \
 		xz-utils \
 		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean

--- a/ubuntu/noble/curl/Dockerfile
+++ b/ubuntu/noble/curl/Dockerfile
@@ -18,4 +18,4 @@ RUN set -eux; \
 # https://bugs.debian.org/929417
 		tzdata \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean

--- a/ubuntu/noble/scm/Dockerfile
+++ b/ubuntu/noble/scm/Dockerfile
@@ -17,4 +17,4 @@ RUN set -eux; \
 # procps is very common in build systems, and is a reasonably small package
 		procps \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean


### PR DESCRIPTION
This has been valid for a while (and I've had it sitting locally on my machine uncommitted for 10 days :joy:), but :partying_face: