### PR TITLE
Adjust trixie to avoid too much riscv64

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -91,10 +91,14 @@ for version; do
 		variantAliases=( "${variantAliases[@]//latest-/}" )
 
 		variantArches="$arches"
-		if [ "$version" = 'ubuntu/focal' ] && [ "$variant" != 'curl' ]; then
-			# focal on riscv64 doesn't have mercurial, so we just exclude the upper focal variants from riscv64 entirely
-			variantArches="$(sed -r -e 's/ riscv64 / /g' <<<" $variantArches ")"
-		fi
+		case "$version" in
+			debian/trixie)
+				# trixie on riscv64 doesn't have git yet (at the very least, probably more once we get past that one), so we just exclude the upper variants for now and can revisit later
+				if [ "$variant" != 'curl' ]; then
+					variantArches="$(sed -r -e 's/ riscv64 / /g' <<<" $variantArches ")"
+				fi
+				;;
+		esac
 
 		echo
 		cat <<-EOE


### PR DESCRIPTION
Trixie doesn't yet have `git` (probably more), but `curl` does build successfully, so this adjusts `generate-stackbrew-library.sh` to exclude `riscv64` from all but `trixie-curl`.

```diff
$ diff -u <(bashbrew cat buildpack-deps) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2024-08-13 10:59:42.728567215 -0700
+++ /dev/fd/62	2024-08-13 10:59:42.732567254 -0700
@@ -47,7 +47,7 @@
 Directory: debian/sid

 Tags: trixie-curl, testing-curl
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 GitCommit: 1f4fe499c668d9a2e1578aa8db4f0b2d14482cf5
 Directory: debian/trixie/curl

```