### PR TITLE
Use `bashbrew` to gather the canonical list of supported suites

### DIFF
--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -14,6 +14,9 @@ fi
 if [ "$#" -eq 0 ]; then
 	versions="$(jq -r 'keys | map(@sh) | join(" ")' versions.json)"
 	eval "set -- $versions"
+
+	# TODO make this cleaner
+	rm -rf debian ubuntu
 fi
 
 generated_warning() {

--- a/versions.sh
+++ b/versions.sh
@@ -3,7 +3,42 @@ set -Eeuo pipefail
 
 distsSuites=( "$@" )
 if [ "${#distsSuites[@]}" -eq 0 ]; then
-	distsSuites=( */*/ )
+	# when run without arguments, let's use "bashbrew" to get the canonical list of currently supported suites/codenames
+	bashbrew --version > /dev/null
+	if [ -z "${BASHBREW_LIBRARY:-}" ] || [ ! -s "$BASHBREW_LIBRARY/debian" ] || [ ! -s "$BASHBREW_LIBRARY/ubuntu" ]; then
+		tempDir="$(mktemp -d)"
+		trap 'rm -rf "$tempDir"' EXIT
+		wget -qO "$tempDir/debian" 'https://github.com/docker-library/official-images/raw/HEAD/library/debian'
+		wget -qO "$tempDir/ubuntu" 'https://github.com/docker-library/official-images/raw/HEAD/library/ubuntu'
+		export BASHBREW_LIBRARY="$tempDir"
+		bashbrew cat debian ubuntu > /dev/null
+	fi
+	dists="$(
+		bashbrew cat debian ubuntu --format '
+				{{- range .Entries -}}
+					{{- $.Tags "" false . | json -}}
+					{{- "\n" -}}
+				{{- end -}}
+			' | jq -r '
+				map(select(test("
+					# a few tags we explicitly want to ignore in our search for codenames
+					:(
+						experimental | rc-buggy # not a release
+						|
+						latest | .*stable | devel | rolling | testing # stable/development/rolling aliases
+						|
+						.* - .* # anything with a hyphen
+						|
+						[0-9].* # likewise with numerics
+					)$
+				"; "x") | not))
+				| .[0] // empty # then we filter to the first leftover in each tag group and it should be the codename
+				| sub(":"; "/")
+				| @sh
+			'
+	)"
+	# TODO expand this and do our supported architectures detection here too, while we've already done the lookups?  Ubuntu version number lookups via this method too?  (unfortunately we can't map Debian codenames to aliases like "stable" this way)
+	eval "distsSuites=( $dists )"
 	json='{}'
 else
 	json="$(< versions.json)"


### PR DESCRIPTION
This is an attempt to help codify #162, and make sure that it's correct / mostly automated.  I'd love to figure out a clean way to help @docker-library-bot be able to make these kinds of updates automatically, but that's a much larger/more complicated problem.

I'm not 100% sold on it, especially how fiddly and frankly unapproachable my filtering method is.